### PR TITLE
Fix - Edge Style Breaks after Re-Render

### DIFF
--- a/packages/graphin/demo/Demo.tsx
+++ b/packages/graphin/demo/Demo.tsx
@@ -1,12 +1,120 @@
-import React from 'react';
+import React, { useLayoutEffect, useContext, useState } from 'react';
 import ReactDOM from 'react-dom';
+import Graphin, { GraphinContext } from '../src';
+import cloneDeep from 'lodash/cloneDeep';
 
-import Graphin, { Utils, GraphinData } from '../src';
+const defaultEdge = {
+  style: {
+    keyshape: {
+      stroke: 'green',
+      strokeOpacity: 1,
+      fillOpacity: 1,
+      opacity: 1,
+      cursor: 'pointer',
+      shadowColor: 'transparent',
+      lineAppendWidth: 9,
+    },
+  },
+};
 
-const data: GraphinData = Utils.mock(8).circle().graphin();
+const edgeStateStyles = {
+  status: {
+    selected: {
+      keyshape: {
+        stroke: '#ddd',
+      },
+    },
+    inactive: {
+      keyshape: {
+        opactiy: 0.5,
+      },
+    },
+  },
+};
+
+const Logger = () => {
+  const { graph } = useContext(GraphinContext);
+  const onEdgeClick = (e): void => {
+    const { item } = e;
+    console.log(item._cfg.keyShape.attrs);
+  };
+
+  useLayoutEffect(() => {
+    graph.on('edge:click', onEdgeClick);
+
+    return (): void => {
+      graph.off('edge:click', onEdgeClick);
+    };
+  }, [graph]);
+
+  return null;
+};
+
+const nodes = [
+  {
+    id: 'node-0',
+    x: 100,
+    y: 200,
+  },
+  {
+    id: 'node-1',
+    x: 600,
+    y: 200,
+  },
+];
+
+const edges = [
+  {
+    id: 'edge-0',
+    source: 'node-0',
+    target: 'node-1',
+    style: {
+      keyshape: {
+        lineWidth: 2,
+        type: 'poly',
+        poly: {
+          distance: 40,
+        },
+      },
+    },
+  },
+];
+
+const layout = {
+  type: 'preset',
+};
+
+const data = { nodes, edges };
 
 const Demo = () => {
-  return <Graphin data={data} />;
+  const [count, setCount] = useState(0);
+  const genData = () => {
+    const newData = cloneDeep(data);
+    newData.edges[0].style = {
+      keyshape: {
+        stroke: 'black',
+        lineWidth: 10,
+        type: 'poly',
+        poly: {
+          distance: 40,
+        },
+      },
+    };
+    return newData;
+  };
+  return (
+    <div>
+      <button onClick={() => setCount(1)}>Update Edge</button>
+      <Graphin
+        defaultEdge={defaultEdge}
+        edgeStateStyles={edgeStateStyles}
+        data={count === 0 ? data : genData()}
+        layout={layout}
+      >
+        <Logger />
+      </Graphin>
+    </div>
+  );
 };
 
 ReactDOM.render(<Demo />, document.getElementById('root'));

--- a/packages/graphin/demo/Demo.tsx
+++ b/packages/graphin/demo/Demo.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import Graphin, { Utils, GraphinData } from '../src';
+
+const data: GraphinData = Utils.mock(8).circle().graphin();
+
+const Demo = () => {
+  return <Graphin data={data} />;
+};
+
+ReactDOM.render(<Demo />, document.getElementById('root'));

--- a/packages/graphin/index.html
+++ b/packages/graphin/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Demo Graphin</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./demo/Demo.tsx"></script>
+  </body>
+</html>

--- a/packages/graphin/npm-shrinkwrap.json
+++ b/packages/graphin/npm-shrinkwrap.json
@@ -22,6 +22,7 @@
         "@testing-library/react": "^9.5.0",
         "@types/jest": "^25.2.3",
         "@types/lodash-es": "^4.17.4",
+        "@vitejs/plugin-react-refresh": "^1.3.3",
         "cross-env": "^5.2.0",
         "css-loader": "^1.0.1",
         "eventemitter3": "^4.0.0",
@@ -39,6 +40,7 @@
         "svg-path-parser": "^1.1.0",
         "ts-jest": "^24.1.0",
         "typescript": "^4.1.3",
+        "vite": "^2.2.4",
         "webpack": "^4.41.5",
         "webpack-bundle-analyzer": "^3.6.0",
         "webpack-cli": "^3.3.10"
@@ -7011,6 +7013,22 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react-refresh": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-refresh/-/plugin-react-refresh-1.3.3.tgz",
+      "integrity": "sha512-J3KFwSQKrEK7fgOwTx0PMTlsolZORUch6BswjsM50q+Y7zSvX1ROIRn+tK2VE8SCvbYRHtzEKFlYW3vsWyTosQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.12.13",
+        "@babel/plugin-transform-react-jsx-self": "^7.12.13",
+        "@babel/plugin-transform-react-jsx-source": "^7.12.13",
+        "react-refresh": "^0.9.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -17718,6 +17736,16 @@
         "ext": "^1.1.2"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.9.7.tgz",
+      "integrity": "sha512-VtUf6aQ89VTmMLKrWHYG50uByMF4JQlVysb8dmg6cOgW8JnFCipmz7p+HNBl+RR3LLCuBxFGVauAe2wfnF9bLg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.1.1",
       "dev": true,
@@ -21038,6 +21066,20 @@
       "version": "1.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -35285,6 +35327,15 @@
         }
       }
     },
+    "node_modules/react-refresh": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.9.0.tgz",
+      "integrity": "sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-select": {
       "version": "3.2.0",
       "dev": true,
@@ -43291,6 +43342,69 @@
         "source-map": "^0.5.1"
       }
     },
+    "node_modules/vite": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.2.4.tgz",
+      "integrity": "sha512-vnIwSNci+phFMp6krhy+FbYzKL0R67Sdt9mVZ96S27AewrApSJjTqncJcalk8sf60BgcbW4+1C6DFIWkxquO9g==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.9.3",
+        "postcss": "^8.2.1",
+        "resolve": "^1.19.0",
+        "rollup": "^2.38.5"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.1"
+      }
+    },
+    "node_modules/vite/node_modules/postcss": {
+      "version": "8.2.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.13.tgz",
+      "integrity": "sha512-FCE5xLH+hjbzRdpbRb1IMCvPv9yZx2QnDarBEYSN0N0HYk+TcXsEhwdFcFb+SRWOKzKGErhIEbBK2ogyLdTtfQ==",
+      "dev": true,
+      "dependencies": {
+        "colorette": "^1.2.2",
+        "nanoid": "^3.1.22",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/vite/node_modules/rollup": {
+      "version": "2.47.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.47.0.tgz",
+      "integrity": "sha512-rqBjgq9hQfW0vRmz+0S062ORRNJXvwRpzxhFXORvar/maZqY6za3rgQ/p1Glg+j1hnc1GtYyQCPiAei95uTElg==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.1"
+      }
+    },
+    "node_modules/vite/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
       "dev": true,
@@ -50108,6 +50222,18 @@
             "@babel/plugin-syntax-decorators": "^7.12.13"
           }
         }
+      }
+    },
+    "@vitejs/plugin-react-refresh": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-refresh/-/plugin-react-refresh-1.3.3.tgz",
+      "integrity": "sha512-J3KFwSQKrEK7fgOwTx0PMTlsolZORUch6BswjsM50q+Y7zSvX1ROIRn+tK2VE8SCvbYRHtzEKFlYW3vsWyTosQ==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.12.13",
+        "@babel/plugin-transform-react-jsx-self": "^7.12.13",
+        "@babel/plugin-transform-react-jsx-source": "^7.12.13",
+        "react-refresh": "^0.9.0"
       }
     },
     "@webassemblyjs/ast": {
@@ -57911,6 +58037,12 @@
         "ext": "^1.1.2"
       }
     },
+    "esbuild": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.9.7.tgz",
+      "integrity": "sha512-VtUf6aQ89VTmMLKrWHYG50uByMF4JQlVysb8dmg6cOgW8JnFCipmz7p+HNBl+RR3LLCuBxFGVauAe2wfnF9bLg==",
+      "dev": true
+    },
     "escalade": {
       "version": "3.1.1",
       "dev": true
@@ -60268,6 +60400,13 @@
     "fs.realpath": {
       "version": "1.0.0",
       "dev": true
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -70209,6 +70348,12 @@
         "react-is": "^16.13.1"
       }
     },
+    "react-refresh": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.9.0.tgz",
+      "integrity": "sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==",
+      "dev": true
+    },
     "react-select": {
       "version": "3.2.0",
       "dev": true,
@@ -75756,6 +75901,47 @@
       "dev": true,
       "requires": {
         "source-map": "^0.5.1"
+      }
+    },
+    "vite": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.2.4.tgz",
+      "integrity": "sha512-vnIwSNci+phFMp6krhy+FbYzKL0R67Sdt9mVZ96S27AewrApSJjTqncJcalk8sf60BgcbW4+1C6DFIWkxquO9g==",
+      "dev": true,
+      "requires": {
+        "esbuild": "^0.9.3",
+        "fsevents": "~2.3.1",
+        "postcss": "^8.2.1",
+        "resolve": "^1.19.0",
+        "rollup": "^2.38.5"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "8.2.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.13.tgz",
+          "integrity": "sha512-FCE5xLH+hjbzRdpbRb1IMCvPv9yZx2QnDarBEYSN0N0HYk+TcXsEhwdFcFb+SRWOKzKGErhIEbBK2ogyLdTtfQ==",
+          "dev": true,
+          "requires": {
+            "colorette": "^1.2.2",
+            "nanoid": "^3.1.22",
+            "source-map": "^0.6.1"
+          }
+        },
+        "rollup": {
+          "version": "2.47.0",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.47.0.tgz",
+          "integrity": "sha512-rqBjgq9hQfW0vRmz+0S062ORRNJXvwRpzxhFXORvar/maZqY6za3rgQ/p1Glg+j1hnc1GtYyQCPiAei95uTElg==",
+          "dev": true,
+          "requires": {
+            "fsevents": "~2.3.1"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "vm-browserify": {

--- a/packages/graphin/package.json
+++ b/packages/graphin/package.json
@@ -11,7 +11,9 @@
     "build:umd": "node --max_old_space_size=8192 ./node_modules/webpack/bin/webpack.js  --env.NODE_ENV=production  -c ./webpack.config.js ",
     "test": "jest",
     "prettier": "prettier --write ./src/**/**/**/*.js",
-    "clean": "rimraf es esm lib dist"
+    "clean": "rimraf es esm lib dist",
+    "dev": "vite --force",
+    "transpile": "tsc --p ./tsconfig.json --noEmit true --strict --watch"
   },
   "devDependencies": {
     "@antv/g-base": "^0.5.5",
@@ -21,6 +23,7 @@
     "@testing-library/react": "^9.5.0",
     "@types/jest": "^25.2.3",
     "@types/lodash-es": "^4.17.4",
+    "@vitejs/plugin-react-refresh": "^1.3.3",
     "cross-env": "^5.2.0",
     "css-loader": "^1.0.1",
     "eventemitter3": "^4.0.0",
@@ -38,6 +41,7 @@
     "svg-path-parser": "^1.1.0",
     "ts-jest": "^24.1.0",
     "typescript": "^4.1.3",
+    "vite": "^2.2.4",
     "webpack": "^4.41.5",
     "webpack-bundle-analyzer": "^3.6.0",
     "webpack-cli": "^3.3.10"

--- a/packages/graphin/src/Graphin.tsx
+++ b/packages/graphin/src/Graphin.tsx
@@ -347,12 +347,16 @@ class Graphin extends React.PureComponent<GraphinProps, GraphinState> {
     if (isOptionsChange) {
       // this.updateOptions();
     }
+
     /** 数据变化 */
     if (isDataChange) {
       this.initData(data);
       this.layout.changeLayout();
+
       this.graph.data(this.data as GraphData | TreeGraphData);
       this.graph.changeData(this.data as GraphData | TreeGraphData);
+
+      this.graph.render();
       this.initStatus();
       this.apis = ApiController(this.graph);
       // console.log('%c isDataChange', 'color:grey');

--- a/packages/graphin/src/index.ts
+++ b/packages/graphin/src/index.ts
@@ -1,14 +1,14 @@
 import Graphin from './Graphin';
-import GraphinContext, { GraphinContextType } from './GraphinContext';
+import GraphinContext from './GraphinContext';
 import Utils from './utils';
 import Behaviors from './behaviors';
 import registerGraphinForce from './layout/inner/registerGraphinForce';
 import registerPresetLayout from './layout/inner/registerPresetLayout';
 import { registerGraphinCircle, registerGraphinLine } from './shape';
 /** export type */
-export { NodeStyle, EdgeStyle, GraphinData, GraphinTreeData, IUserEdge, IUserNode, Layout } from './typings/type';
-export { ThemeType } from './theme';
-export { GraphinContextType };
+export type { GraphinContextType } from './GraphinContext';
+export type { NodeStyle, EdgeStyle, GraphinData, GraphinTreeData, IUserEdge, IUserNode, Layout } from './typings/type';
+export type { ThemeType } from './theme';
 
 /** 注册 Graphin force 布局 */
 registerGraphinForce();
@@ -28,17 +28,8 @@ const { registerFontFamily } = Graphin;
 export default Graphin;
 export { Utils, GraphinContext, Behaviors, registerFontFamily };
 
-export {
-  /** export G6 */
-  default as G6,
-  /** export G6 Type  */
-  Graph,
-  IG6GraphEvent,
-  GraphData,
-  TreeGraphData,
-  NodeConfig,
-  EdgeConfig,
-} from '@antv/g6';
+export { default as G6 } from '@antv/g6';
+export type { Graph, IG6GraphEvent, GraphData, TreeGraphData, NodeConfig, EdgeConfig } from '@antv/g6';
 
 export interface GraphEvent extends MouseEvent {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/graphin/vite.config.ts
+++ b/packages/graphin/vite.config.ts
@@ -1,0 +1,9 @@
+import reactRefresh from '@vitejs/plugin-react-refresh';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [reactRefresh()],
+  optimizeDeps: {
+    keepNames: true,
+  },
+});


### PR DESCRIPTION
## Description 

- Construct Development environment to test out `Graphin` component since we are unable to develop with `dumi dev` as there are npm dependencies and link issues with other `@antv/*` component during `lerna bootstrap`. 
- Fix edge style breaks during re-render with `componentDidUpdate`. 

## Steps to test the fixes

1. perform `npm install` in `packages/graphin` 
2. run `npm run dev` 
3. Press the edge and view the `attrs` metadata in console. 
4. Press [Update Edge]
5. Press the edge again and view the `attrs` metadata in console, notice the `edgeLineWidth` is not zero and other attributes are combined with `defaultEdge`. 
